### PR TITLE
Fix video lipsync ending too soon and add run scripts

### DIFF
--- a/frontend/src/VideoLipsync.tsx
+++ b/frontend/src/VideoLipsync.tsx
@@ -239,7 +239,7 @@ export default function VideoLipsync({ comfyUrl }: Props) {
       
       // Calculate timing parameters
       const audioStartTime = audioTrack ? `${Math.floor(audioTrack.startTime / 60)}:${String(Math.floor(audioTrack.startTime % 60)).padStart(2, '0')}` : "0:00";
-      const audioEndTime = audioTrack ? `${Math.floor((audioTrack.startTime + audioTrack.duration) / 60)}:${String(Math.floor((audioTrack.startTime + audioTrack.duration) % 60)).padStart(2, '0')}` : "2:00";
+      const audioEndTime = audioTrack ? `${Math.floor((audioTrack.startTime + audioTrack.duration) / 60)}:${String(Math.ceil((audioTrack.startTime + audioTrack.duration) % 60)).padStart(2, '0')}` : "2:00";
       const videoStartFrame = videoTrack ? Math.floor(videoTrack.startTime * 25) : 0; // Assuming 25 FPS
       
       // Calculate black frame padding based on timeline union

--- a/runbackend.sh
+++ b/runbackend.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "$(dirname "$0")/backend"
+source venv/bin/activate
+python -m uvicorn main:app --reload --port 8000

--- a/runfrontend.sh
+++ b/runfrontend.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")/frontend"
+npm run dev


### PR DESCRIPTION
- Change Math.floor to Math.ceil for audio end time calculation to prevent truncating fractional seconds (fixes videos ending early)
- Add runbackend.sh and runfrontend.sh convenience scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)