### PR TITLE
fix: Use portal for ImageModal to escape container constraints

### DIFF
--- a/frontend/src/components/GenerationFeed.tsx
+++ b/frontend/src/components/GenerationFeed.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { apiClient } from '../lib/apiClient'
 import { useComfyUIProgress } from '../hooks/useComfyUIProgress'
 import { fixStuckJob } from '../lib/fixStuckJob'
@@ -639,8 +640,8 @@ export default function GenerationFeed({ config, onUpscaleComplete }: Generation
         )}
       </div>
 
-      {/* Image Modal */}
-      {selectedImage && (
+      {/* Image Modal - rendered in portal to escape container constraints */}
+      {selectedImage && createPortal(
         <ImageModal
           image={selectedImage}
           isOpen={!!selectedImage}
@@ -654,7 +655,8 @@ export default function GenerationFeed({ config, onUpscaleComplete }: Generation
             loadFeed(true)
             if (onUpscaleComplete) onUpscaleComplete()
           }}
-        />
+        />,
+        document.body
       )}
     </div>
   )


### PR DESCRIPTION
The modal was being clipped by the overflow-y-auto container of the GenerationFeed sidebar. Using createPortal renders it at document.body level so it displays full-page as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)