### PR TITLE
Drive QA viewer for Max Wild 1x03

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,13 @@ jobs:
     name: Backend Tests
     runs-on: ubuntu-latest
 
+    # Dummy creds required at import time by the screenwriter sub-app
+    # (EmbeddingService instantiates AsyncOpenAI at module load, and newer
+    # openai SDK versions validate the api_key eagerly). Tests don't make
+    # real calls.
+    env:
+      OPENAI_API_KEY: sk-dummy-for-ci
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/backend/api/drive_qa.py
+++ b/backend/api/drive_qa.py
@@ -1,0 +1,161 @@
+"""API endpoints for the Drive QA Viewer.
+
+Exposes:
+  GET  /drive-qa/episode                 → episode metadata (hardcoded Max Wild 1x03)
+  GET  /drive-qa/scenes                  → list of scene folders
+  GET  /drive-qa/scenes/{scene_id}       → scene with assets + results
+  GET  /drive-qa/file/{file_id}          → raw image bytes (proxy)
+  GET  /drive-qa/file/{file_id}/thumbnail → small thumbnail bytes (proxy)
+  GET  /drive-qa/reviews                 → all reviews for the current episode
+  POST /drive-qa/reviews                 → upsert a review for a scene
+"""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+
+from core.auth import get_current_user
+from models.drive_qa import (
+    QAReviewListResponse,
+    QAReviewResponse,
+    QAReviewUpsertRequest,
+    QASceneDetailResponse,
+    QASceneListResponse,
+)
+from services.drive_qa_service import (
+    EPISODE_ID,
+    EPISODE_NAME,
+    DriveQAReviewService,
+    DriveQAService,
+)
+
+
+router = APIRouter(prefix="/drive-qa", tags=["drive-qa"])
+
+
+# ---------------------------------------------------------------------------
+# Episode + scenes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/episode")
+async def get_episode(_: dict = Depends(get_current_user)) -> dict:
+    """Return the hardcoded episode currently exposed by the viewer."""
+    return {"id": EPISODE_ID, "name": EPISODE_NAME}
+
+
+@router.get("/scenes", response_model=QASceneListResponse)
+async def list_scenes(
+    _: dict = Depends(get_current_user),
+) -> QASceneListResponse:
+    service = DriveQAService()
+    success, scenes, error = await service.list_scenes()
+    return QASceneListResponse(
+        success=success,
+        episode_id=EPISODE_ID,
+        episode_name=EPISODE_NAME,
+        scenes=scenes,
+        error=error,
+    )
+
+
+@router.get("/scenes/{scene_id}", response_model=QASceneDetailResponse)
+async def get_scene(
+    scene_id: str,
+    _: dict = Depends(get_current_user),
+) -> QASceneDetailResponse:
+    service = DriveQAService()
+    success, scene, error = await service.get_scene_detail(scene_id)
+    return QASceneDetailResponse(success=success, scene=scene, error=error)
+
+
+# ---------------------------------------------------------------------------
+# File proxy (so the frontend can render Drive images with our auth)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/file/{file_id}")
+async def get_file_bytes(
+    file_id: str,
+    _: dict = Depends(get_current_user),
+) -> Response:
+    """Stream the full image bytes for a Drive file."""
+    service = DriveQAService()
+    success, content, mime_type, error = await service.download_file(file_id)
+    if not success or content is None:
+        raise HTTPException(status_code=502, detail=error or "Drive download failed")
+    return Response(
+        content=content,
+        media_type=mime_type or "application/octet-stream",
+        headers={"Cache-Control": "private, max-age=3600"},
+    )
+
+
+@router.get("/file/{file_id}/thumbnail")
+async def get_file_thumbnail(
+    file_id: str,
+    size: int = Query(400, ge=64, le=2000),
+    _: dict = Depends(get_current_user),
+) -> Response:
+    """Proxy a Drive-generated thumbnail (smaller than the full image)."""
+    service = DriveQAService()
+    success, url, error = await service.get_thumbnail_url(file_id, size_px=size)
+    if not success or not url:
+        # Fall back to the full image if the thumbnail is unavailable.
+        full_success, content, mime, full_error = await service.download_file(file_id)
+        if not full_success or content is None:
+            raise HTTPException(
+                status_code=502,
+                detail=error or full_error or "Drive thumbnail unavailable",
+            )
+        return Response(
+            content=content,
+            media_type=mime or "image/jpeg",
+            headers={"Cache-Control": "private, max-age=3600"},
+        )
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.get(url)
+            r.raise_for_status()
+    except httpx.HTTPError as e:
+        raise HTTPException(status_code=502, detail=f"Thumbnail fetch failed: {e}")
+
+    return Response(
+        content=r.content,
+        media_type=r.headers.get("content-type", "image/jpeg"),
+        headers={"Cache-Control": "private, max-age=3600"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reviews
+# ---------------------------------------------------------------------------
+
+
+@router.get("/reviews", response_model=QAReviewListResponse)
+async def list_reviews(
+    _: dict = Depends(get_current_user),
+) -> QAReviewListResponse:
+    service = DriveQAReviewService()
+    success, reviews, error = await service.list_for_episode(EPISODE_ID)
+    return QAReviewListResponse(success=success, reviews=reviews, error=error)
+
+
+@router.post("/reviews", response_model=QAReviewResponse)
+async def upsert_review(
+    payload: QAReviewUpsertRequest,
+    current_user=Depends(get_current_user),
+) -> QAReviewResponse:
+    service = DriveQAReviewService()
+    success, review, error = await service.upsert(
+        user_id=current_user.id,
+        episode_id=payload.episode_id,
+        scene_id=payload.scene_id,
+        scene_name=payload.scene_name,
+        status=payload.status,
+        notes=payload.notes,
+    )
+    return QAReviewResponse(success=success, review=review, error=error)

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import os
 
-from api import storage, datasets, image_edit, comfyui, multitalk, auth, image_jobs, video_jobs, world_jobs, flux_trainer, lora_trainer, feed, google_drive, virtual_set, runpod, infrastructure, api_keys, upscale, custom_workflows
+from api import storage, datasets, image_edit, comfyui, multitalk, auth, image_jobs, video_jobs, world_jobs, flux_trainer, lora_trainer, feed, google_drive, virtual_set, runpod, infrastructure, api_keys, upscale, custom_workflows, drive_qa
 from services.upscale_job_service import UpscaleJobService
 
 # Screenwriter sub-application
@@ -96,6 +96,7 @@ app.include_router(api_keys.router, prefix="/api")
 app.include_router(infrastructure.router)
 app.include_router(upscale.router, prefix="/api")
 app.include_router(custom_workflows.router)
+app.include_router(drive_qa.router, prefix="/api")
 
 # Screenwriter sub-application — all screenwriter endpoints under /api/screenwriter/*
 app.include_router(screenwriter_router, prefix="/api/screenwriter")

--- a/backend/migrations/009_add_drive_qa_reviews.sql
+++ b/backend/migrations/009_add_drive_qa_reviews.sql
@@ -1,0 +1,138 @@
+-- Migration: Add Drive QA Reviews
+-- Date: 2026-05-12
+-- Description: Create drive_qa_reviews table for QA tracking of Drive scenes.
+--              Stores per-user OK/NOK status and notes for each scene in the
+--              Drive QA viewer.
+
+-- ============================================================================
+-- STEP 1: Create drive_qa_reviews table
+-- ============================================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'drive_qa_reviews'
+    ) THEN
+        CREATE TABLE drive_qa_reviews (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+            -- Drive identifiers
+            episode_id TEXT NOT NULL,
+            scene_id TEXT NOT NULL,
+            scene_name TEXT NOT NULL,
+
+            -- QA state
+            status TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending', 'ok', 'nok')),
+            notes TEXT,
+
+            -- Ownership
+            user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+            -- Timestamps
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+            -- One review per user per scene
+            UNIQUE (user_id, scene_id)
+        );
+        RAISE NOTICE 'Created drive_qa_reviews table';
+    ELSE
+        RAISE NOTICE 'drive_qa_reviews table already exists';
+    END IF;
+END $$;
+
+-- ============================================================================
+-- STEP 2: Create indexes
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_drive_qa_reviews_episode
+    ON drive_qa_reviews(episode_id);
+
+CREATE INDEX IF NOT EXISTS idx_drive_qa_reviews_user
+    ON drive_qa_reviews(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_drive_qa_reviews_scene
+    ON drive_qa_reviews(scene_id);
+
+-- ============================================================================
+-- STEP 3: updated_at trigger
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_drive_qa_reviews_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_drive_qa_reviews_updated_at ON drive_qa_reviews;
+CREATE TRIGGER trg_drive_qa_reviews_updated_at
+    BEFORE UPDATE ON drive_qa_reviews
+    FOR EACH ROW
+    EXECUTE FUNCTION update_drive_qa_reviews_updated_at();
+
+-- ============================================================================
+-- STEP 4: Row-Level Security
+-- ============================================================================
+
+ALTER TABLE drive_qa_reviews ENABLE ROW LEVEL SECURITY;
+
+-- All authenticated users can read all reviews (team-wide visibility)
+DROP POLICY IF EXISTS "Authenticated can read all reviews" ON drive_qa_reviews;
+CREATE POLICY "Authenticated can read all reviews"
+    ON drive_qa_reviews FOR SELECT
+    TO authenticated
+    USING (true);
+
+-- Users can only insert/update/delete their own reviews
+DROP POLICY IF EXISTS "Users can insert own reviews" ON drive_qa_reviews;
+CREATE POLICY "Users can insert own reviews"
+    ON drive_qa_reviews FOR INSERT
+    TO authenticated
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can update own reviews" ON drive_qa_reviews;
+CREATE POLICY "Users can update own reviews"
+    ON drive_qa_reviews FOR UPDATE
+    TO authenticated
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can delete own reviews" ON drive_qa_reviews;
+CREATE POLICY "Users can delete own reviews"
+    ON drive_qa_reviews FOR DELETE
+    TO authenticated
+    USING (auth.uid() = user_id);
+
+-- ============================================================================
+-- STEP 5: Comments
+-- ============================================================================
+
+COMMENT ON TABLE drive_qa_reviews IS 'Per-user QA review status for Drive scenes in the QA viewer';
+COMMENT ON COLUMN drive_qa_reviews.episode_id IS 'Google Drive folder ID of the episode (e.g., Max Wild 1x03)';
+COMMENT ON COLUMN drive_qa_reviews.scene_id IS 'Google Drive folder ID of the scene';
+COMMENT ON COLUMN drive_qa_reviews.scene_name IS 'Human-readable scene name (e.g., "Scene 07") for display';
+COMMENT ON COLUMN drive_qa_reviews.status IS 'QA verdict: pending (not reviewed), ok (approved), nok (needs rework)';
+
+-- ============================================================================
+-- STEP 6: Verify
+-- ============================================================================
+
+DO $$
+DECLARE
+    table_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'drive_qa_reviews'
+    ) INTO table_exists;
+
+    IF table_exists THEN
+        RAISE NOTICE 'Migration 009_add_drive_qa_reviews completed successfully!';
+    ELSE
+        RAISE WARNING 'Migration may have failed - please check table creation';
+    END IF;
+END $$;

--- a/backend/models/drive_qa.py
+++ b/backend/models/drive_qa.py
@@ -1,0 +1,86 @@
+"""Pydantic models for the Drive QA Viewer."""
+
+from datetime import datetime
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+ReviewStatus = Literal["pending", "ok", "nok"]
+
+
+class QAImage(BaseModel):
+    """A single image file (asset or result) inside a scene."""
+
+    id: str
+    name: str
+    mime_type: str
+    size: Optional[int] = None
+    modified_time: Optional[datetime] = None
+
+
+class QAScene(BaseModel):
+    """A scene in the QA viewer (lightweight; no file lists)."""
+
+    id: str
+    name: str
+    modified_time: Optional[datetime] = None
+
+
+class QASceneListResponse(BaseModel):
+    success: bool
+    episode_id: str
+    episode_name: Optional[str] = None
+    scenes: List[QAScene] = []
+    error: Optional[str] = None
+
+
+class QASceneDetail(BaseModel):
+    """Full scene contents split into assets and results."""
+
+    id: str
+    name: str
+    assets: List[QAImage] = Field(default_factory=list)
+    results: List[QAImage] = Field(default_factory=list)
+
+
+class QASceneDetailResponse(BaseModel):
+    success: bool
+    scene: Optional[QASceneDetail] = None
+    error: Optional[str] = None
+
+
+class QAReview(BaseModel):
+    """A QA review record."""
+
+    id: str
+    episode_id: str
+    scene_id: str
+    scene_name: str
+    status: ReviewStatus
+    notes: Optional[str] = None
+    user_id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class QAReviewUpsertRequest(BaseModel):
+    """Request body to create or update a review."""
+
+    episode_id: str
+    scene_id: str
+    scene_name: str
+    status: ReviewStatus
+    notes: Optional[str] = None
+
+
+class QAReviewResponse(BaseModel):
+    success: bool
+    review: Optional[QAReview] = None
+    error: Optional[str] = None
+
+
+class QAReviewListResponse(BaseModel):
+    success: bool
+    reviews: List[QAReview] = Field(default_factory=list)
+    error: Optional[str] = None

--- a/backend/services/drive_qa_service.py
+++ b/backend/services/drive_qa_service.py
@@ -1,0 +1,340 @@
+"""Service for the Drive QA Viewer.
+
+Reads Drive contents organized by episode/scene and exposes them in the
+shape the QA viewer expects: each scene is split into "assets" (files inside
+the scene's `Assets/` subfolder) and "results" (image files directly under
+the scene folder).
+
+Episode and the inner "3. Master Shot - Layout" folder IDs are hardcoded for
+now (Max Wild 1x03). When we need to support more episodes, extract these
+into a registry or DB table.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from typing import List, Optional, Tuple
+
+from googleapiclient.http import MediaIoBaseDownload
+
+from core.google_drive import get_drive_client, is_drive_configured
+from core.supabase import get_supabase
+from models.drive_qa import QAImage, QAReview, QAScene, QASceneDetail, ReviewStatus
+
+
+# ---------------------------------------------------------------------------
+# Hardcoded Drive IDs for Max Wild 1x03
+# ---------------------------------------------------------------------------
+
+EPISODE_ID = "1_yPGxVUQ5C55jfvmbN93WH6uLfiKivUq"  # "Max Wild 1x03 (NUESTRA CARPETA)"
+EPISODE_NAME = "Max Wild 1x03"
+MASTER_SHOT_FOLDER_ID = "14wcpCuIoNw8EDf7agFdW6MXlzASWie-A"  # "3. Master Shot - Layout"
+
+FOLDER_MIME = "application/vnd.google-apps.folder"
+IMAGE_MIME_PREFIX = "image/"
+
+# Matches "Scene 07", "scene 7", "Scene 7 - foo", etc. Used to sort and to
+# filter out auxiliary folders like "TK01 - To Check".
+_SCENE_RE = re.compile(r"^\s*scene\s*0*(\d+)", re.IGNORECASE)
+
+
+def _scene_sort_key(name: str) -> Tuple[int, str]:
+    """Sort scenes numerically by their scene number; non-matches go last."""
+    m = _SCENE_RE.match(name)
+    if m:
+        return (int(m.group(1)), name)
+    return (10_000, name)
+
+
+class DriveQAService:
+    """Read-only Drive accessor for the QA viewer."""
+
+    def __init__(self) -> None:
+        if is_drive_configured():
+            self.drive = get_drive_client()
+        else:
+            self.drive = None
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+
+    async def list_scenes(self) -> Tuple[bool, List[QAScene], Optional[str]]:
+        """List all scene folders under '3. Master Shot - Layout', sorted."""
+        if not self.drive:
+            return False, [], "Google Drive not configured"
+
+        try:
+            scenes: List[QAScene] = []
+            page_token: Optional[str] = None
+
+            while True:
+                resp = self.drive.files().list(
+                    q=(
+                        f"'{MASTER_SHOT_FOLDER_ID}' in parents "
+                        f"and mimeType = '{FOLDER_MIME}' "
+                        f"and trashed = false"
+                    ),
+                    supportsAllDrives=True,
+                    includeItemsFromAllDrives=True,
+                    pageSize=100,
+                    pageToken=page_token,
+                    fields="nextPageToken, files(id, name, modifiedTime)",
+                ).execute()
+
+                for item in resp.get("files", []):
+                    name = item["name"]
+                    # Keep only "Scene NN" folders, drop "TK01 - To Check" etc.
+                    if not _SCENE_RE.match(name):
+                        continue
+                    scenes.append(
+                        QAScene(
+                            id=item["id"],
+                            name=name,
+                            modified_time=item.get("modifiedTime"),
+                        )
+                    )
+
+                page_token = resp.get("nextPageToken")
+                if not page_token:
+                    break
+
+            scenes.sort(key=lambda s: _scene_sort_key(s.name))
+            return True, scenes, None
+
+        except Exception as e:
+            return False, [], str(e)
+
+    async def get_scene_detail(
+        self, scene_id: str
+    ) -> Tuple[bool, Optional[QASceneDetail], Optional[str]]:
+        """Return the scene split into assets (subfolder) and results (root images)."""
+        if not self.drive:
+            return False, None, "Google Drive not configured"
+
+        try:
+            # Verify the scene exists and grab its name.
+            scene_meta = self.drive.files().get(
+                fileId=scene_id,
+                supportsAllDrives=True,
+                fields="id, name, mimeType",
+            ).execute()
+
+            if scene_meta.get("mimeType") != FOLDER_MIME:
+                return False, None, "Provided ID is not a folder"
+
+            scene_name = scene_meta["name"]
+
+            # List everything directly under the scene folder.
+            children = await self._list_children(scene_id)
+
+            # Results = image files directly in the scene folder.
+            results: List[QAImage] = [
+                _to_qa_image(c)
+                for c in children
+                if c["mimeType"].startswith(IMAGE_MIME_PREFIX)
+            ]
+            results.sort(key=lambda i: i.name.lower())
+
+            # Assets = images inside the scene's `Assets/` subfolder (if any).
+            assets_folder = next(
+                (
+                    c
+                    for c in children
+                    if c["mimeType"] == FOLDER_MIME
+                    and c["name"].strip().lower() == "assets"
+                ),
+                None,
+            )
+
+            assets: List[QAImage] = []
+            if assets_folder:
+                asset_children = await self._list_children(assets_folder["id"])
+                assets = [
+                    _to_qa_image(c)
+                    for c in asset_children
+                    if c["mimeType"].startswith(IMAGE_MIME_PREFIX)
+                ]
+                assets.sort(key=lambda i: i.name.lower())
+
+            return (
+                True,
+                QASceneDetail(
+                    id=scene_id,
+                    name=scene_name,
+                    assets=assets,
+                    results=results,
+                ),
+                None,
+            )
+
+        except Exception as e:
+            return False, None, str(e)
+
+    # ------------------------------------------------------------------
+    # Binary download
+    # ------------------------------------------------------------------
+
+    async def download_file(
+        self, file_id: str
+    ) -> Tuple[bool, Optional[bytes], Optional[str], Optional[str]]:
+        """Download the full bytes of a Drive file.
+
+        Returns (success, content, mime_type, error).
+        """
+        if not self.drive:
+            return False, None, None, "Google Drive not configured"
+
+        try:
+            meta = self.drive.files().get(
+                fileId=file_id,
+                supportsAllDrives=True,
+                fields="id, name, mimeType",
+            ).execute()
+            mime_type = meta.get("mimeType", "application/octet-stream")
+
+            request = self.drive.files().get_media(
+                fileId=file_id,
+                supportsAllDrives=True,
+            )
+            buf = io.BytesIO()
+            downloader = MediaIoBaseDownload(buf, request)
+            done = False
+            while not done:
+                _status, done = downloader.next_chunk()
+
+            return True, buf.getvalue(), mime_type, None
+
+        except Exception as e:
+            return False, None, None, str(e)
+
+    async def get_thumbnail_url(
+        self, file_id: str, size_px: int = 800
+    ) -> Tuple[bool, Optional[str], Optional[str]]:
+        """Get a Drive-generated thumbnail link, resized to `size_px` on the long side.
+
+        Drive's thumbnailLink looks like `...=s220`; we swap the size param.
+        Returns (success, url, error).
+        """
+        if not self.drive:
+            return False, None, "Google Drive not configured"
+
+        try:
+            meta = self.drive.files().get(
+                fileId=file_id,
+                supportsAllDrives=True,
+                fields="id, thumbnailLink",
+            ).execute()
+            link = meta.get("thumbnailLink")
+            if not link:
+                return False, None, "No thumbnail available"
+
+            # Drive returns links ending in `=sNNN`; resize by replacing it.
+            resized = re.sub(r"=s\d+(-c)?$", f"=s{size_px}", link)
+            return True, resized, None
+
+        except Exception as e:
+            return False, None, str(e)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _list_children(self, folder_id: str) -> list[dict]:
+        """List every child of a folder, paginating through results."""
+        if not self.drive:
+            return []
+
+        drive = self.drive
+        all_items: list[dict] = []
+        page_token: Optional[str] = None
+
+        while True:
+            resp = drive.files().list(
+                q=f"'{folder_id}' in parents and trashed = false",
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
+                pageSize=200,
+                pageToken=page_token,
+                fields=(
+                    "nextPageToken, "
+                    "files(id, name, mimeType, size, modifiedTime)"
+                ),
+            ).execute()
+            all_items.extend(resp.get("files", []))
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                break
+
+        return all_items
+
+
+def _to_qa_image(item: dict) -> QAImage:
+    return QAImage(
+        id=item["id"],
+        name=item["name"],
+        mime_type=item["mimeType"],
+        size=int(item["size"]) if item.get("size") else None,
+        modified_time=item.get("modifiedTime"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reviews (Supabase)
+# ---------------------------------------------------------------------------
+
+
+class DriveQAReviewService:
+    """CRUD for drive_qa_reviews on Supabase."""
+
+    TABLE = "drive_qa_reviews"
+
+    def __init__(self, supabase=None) -> None:
+        self.supabase = supabase or get_supabase()
+
+    async def list_for_episode(
+        self, episode_id: str
+    ) -> Tuple[bool, List[QAReview], Optional[str]]:
+        try:
+            resp = (
+                self.supabase.table(self.TABLE)
+                .select("*")
+                .eq("episode_id", episode_id)
+                .execute()
+            )
+            rows: list = resp.data or []
+            reviews = [QAReview.model_validate(row) for row in rows]
+            return True, reviews, None
+        except Exception as e:
+            return False, [], str(e)
+
+    async def upsert(
+        self,
+        user_id: str,
+        episode_id: str,
+        scene_id: str,
+        scene_name: str,
+        status: ReviewStatus,
+        notes: Optional[str],
+    ) -> Tuple[bool, Optional[QAReview], Optional[str]]:
+        try:
+            payload = {
+                "user_id": user_id,
+                "episode_id": episode_id,
+                "scene_id": scene_id,
+                "scene_name": scene_name,
+                "status": status,
+                "notes": notes,
+            }
+            resp = (
+                self.supabase.table(self.TABLE)
+                .upsert(payload, on_conflict="user_id,scene_id")
+                .execute()
+            )
+            rows: list = resp.data or []
+            if not rows:
+                return False, None, "Upsert returned no row"
+            return True, QAReview.model_validate(rows[0]), None
+        except Exception as e:
+            return False, None, str(e)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -516,7 +516,7 @@ export default function App() {
                   }`}
                 >
                   <span className="text-lg">🎬</span>
-                  <span className="font-medium">Drive QA</span>
+                  <span className="font-medium">Max Wild ep 3 QA</span>
                 </button>
               </div>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import ProfileSettings from "./ProfileSettings";
 import StudioPage from "./components/StudioPage";
 import Infrastructure from "./pages/Infrastructure";
 import DynamicWorkflowPage from "./pages/DynamicWorkflowPage";
+import DriveQA from "./pages/DriveQA";
 // Lazy-load the screenwriting studio to keep the main bundle lean
 const ScreenwritingStudio = lazy(() => import("./features/screenwriting/ScreenwritingStudio"));
 // UI Components
@@ -151,6 +152,7 @@ export default function App() {
     'infrastructure-studio',
     'screenwriting-studio',
     'history',
+    'drive-qa',
     'profile-settings'
   ];
 
@@ -505,6 +507,17 @@ export default function App() {
                   <span className="text-lg">📋</span>
                   <span className="font-medium">History</span>
                 </button>
+                <button
+                  onClick={() => handlePageChange("drive-qa")}
+                  className={`w-full mt-1 flex items-center gap-3 px-4 py-3 rounded-xl text-left transition-all duration-200 ${
+                    currentPage === "drive-qa"
+                      ? "bg-gradient-to-r from-amber-500 to-orange-600 text-white shadow-lg"
+                      : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                  }`}
+                >
+                  <span className="text-lg">🎬</span>
+                  <span className="font-medium">Drive QA</span>
+                </button>
               </div>
 
               {/* External Tools Section */}
@@ -623,6 +636,8 @@ export default function App() {
             <Infrastructure comfyUrl={comfyUrl} />
           ) : currentPage === "history" ? (
             <GenerationFeed />
+          ) : currentPage === "drive-qa" ? (
+            <DriveQA />
           ) : currentPage === "profile-settings" ? (
             <ProfileSettings onNavigateBack={() => setCurrentPage("home")} />
           ) : null}

--- a/frontend/src/lib/studioConfig.ts
+++ b/frontend/src/lib/studioConfig.ts
@@ -281,7 +281,7 @@ export const standaloneApps: AppConfig[] = [
   },
   {
     id: 'drive-qa',
-    title: 'Drive QA',
+    title: 'Max Wild ep 3 QA',
     icon: '🎬',
     gradient: 'from-amber-500 to-orange-600',
     description: 'Side-by-side QA viewer for Drive scenes. Compare assets vs results per shot with synced zoom and OK/NOK tracking.',

--- a/frontend/src/lib/studioConfig.ts
+++ b/frontend/src/lib/studioConfig.ts
@@ -278,6 +278,15 @@ export const standaloneApps: AppConfig[] = [
     description: 'View and manage all your AI generations in one place. Browse videos, images, and style transfers with real-time updates.',
     features: ['All generations in one view', 'Filter by type', 'Real-time progress tracking'],
     fullWidth: true
+  },
+  {
+    id: 'drive-qa',
+    title: 'Drive QA',
+    icon: '🎬',
+    gradient: 'from-amber-500 to-orange-600',
+    description: 'Side-by-side QA viewer for Drive scenes. Compare assets vs results per shot with synced zoom and OK/NOK tracking.',
+    features: ['Assets vs Results side-by-side', 'Synced zoom & pan', 'Per-scene OK/NOK review notes'],
+    fullWidth: true
   }
 ];
 
@@ -369,4 +378,5 @@ export type StudioPageType =
   | 'infrastructure-studio'
   | 'screenwriting-studio'
   | 'history'
+  | 'drive-qa'
   | 'profile-settings';

--- a/frontend/src/pages/DriveQA.tsx
+++ b/frontend/src/pages/DriveQA.tsx
@@ -1,0 +1,608 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { config } from "../config/environment";
+
+// ---------------------------------------------------------------------------
+// Types matching backend models
+// ---------------------------------------------------------------------------
+
+type ReviewStatus = "pending" | "ok" | "nok";
+
+interface QAScene {
+  id: string;
+  name: string;
+  modified_time?: string | null;
+}
+
+interface QAImage {
+  id: string;
+  name: string;
+  mime_type: string;
+  size?: number | null;
+  modified_time?: string | null;
+}
+
+interface QASceneDetail {
+  id: string;
+  name: string;
+  assets: QAImage[];
+  results: QAImage[];
+}
+
+interface QAReview {
+  id: string;
+  episode_id: string;
+  scene_id: string;
+  scene_name: string;
+  status: ReviewStatus;
+  notes?: string | null;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ViewerTransform {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+const INITIAL_TRANSFORM: ViewerTransform = { scale: 1, x: 0, y: 0 };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("vapai-auth-token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function apiGet<T>(path: string): Promise<T> {
+  const r = await fetch(`${config.apiBaseUrl}${path}`, {
+    headers: { ...authHeaders() },
+  });
+  if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+  return r.json() as Promise<T>;
+}
+
+async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const r = await fetch(`${config.apiBaseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+  return r.json() as Promise<T>;
+}
+
+// Build a URL the <img> can hit — needs auth, so we use blob URLs via fetch.
+function buildFileUrl(fileId: string, thumbnail = false, size = 1200): string {
+  const suffix = thumbnail ? `/thumbnail?size=${size}` : "";
+  return `${config.apiBaseUrl}/drive-qa/file/${fileId}${suffix}`;
+}
+
+// ---------------------------------------------------------------------------
+// Authenticated <img> — fetches the bytes via apiClient auth, returns a blob URL.
+// ---------------------------------------------------------------------------
+
+function useBlobUrl(url: string | null): { src: string | null; loading: boolean; error: string | null } {
+  const [src, setSrc] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!url) {
+      setSrc(null);
+      return;
+    }
+    let cancelled = false;
+    let blobUrl: string | null = null;
+    setLoading(true);
+    setError(null);
+    fetch(url, { headers: authHeaders() })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        const blob = await r.blob();
+        blobUrl = URL.createObjectURL(blob);
+        if (!cancelled) {
+          setSrc(blobUrl);
+          setLoading(false);
+        } else {
+          URL.revokeObjectURL(blobUrl);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load");
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+  }, [url]);
+
+  return { src, loading, error };
+}
+
+// ---------------------------------------------------------------------------
+// Synced viewer pane — image + zoom/pan controlled from a shared transform
+// ---------------------------------------------------------------------------
+
+interface ViewerPaneProps {
+  title: string;
+  emptyLabel: string;
+  images: QAImage[];
+  selectedIndex: number;
+  onSelect: (i: number) => void;
+  transform: ViewerTransform;
+  onTransformChange: (t: ViewerTransform) => void;
+}
+
+function ViewerPane({
+  title,
+  emptyLabel,
+  images,
+  selectedIndex,
+  onSelect,
+  transform,
+  onTransformChange,
+}: ViewerPaneProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef<{ startX: number; startY: number; tx: number; ty: number } | null>(
+    null
+  );
+
+  const currentImage = images[selectedIndex] ?? null;
+  const imageUrl = currentImage ? buildFileUrl(currentImage.id) : null;
+  const { src, loading, error } = useBlobUrl(imageUrl);
+
+  // Zoom on wheel — anchor zoom around the cursor position.
+  const handleWheel = useCallback(
+    (e: React.WheelEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const mouseX = e.clientX - rect.left - rect.width / 2;
+      const mouseY = e.clientY - rect.top - rect.height / 2;
+
+      const zoomFactor = Math.exp(-e.deltaY * 0.0015);
+      const newScale = Math.min(8, Math.max(0.2, transform.scale * zoomFactor));
+      const ratio = newScale / transform.scale;
+
+      onTransformChange({
+        scale: newScale,
+        x: mouseX - (mouseX - transform.x) * ratio,
+        y: mouseY - (mouseY - transform.y) * ratio,
+      });
+    },
+    [onTransformChange, transform]
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      draggingRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        tx: transform.x,
+        ty: transform.y,
+      };
+    },
+    [transform]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return;
+      const { startX, startY, tx, ty } = draggingRef.current;
+      onTransformChange({
+        ...transform,
+        x: tx + (e.clientX - startX),
+        y: ty + (e.clientY - startY),
+      });
+    },
+    [onTransformChange, transform]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    draggingRef.current = null;
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full min-h-0 rounded-2xl border border-gray-200 bg-white overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-gray-50">
+        <h3 className="font-semibold text-sm text-gray-800">{title}</h3>
+        <span className="text-xs text-gray-500">
+          {images.length === 0
+            ? "—"
+            : `${selectedIndex + 1} / ${images.length}`}
+        </span>
+      </div>
+
+      {/* Main image area */}
+      <div
+        ref={containerRef}
+        className="flex-1 relative overflow-hidden bg-[#1a1a1a] flex items-center justify-center select-none cursor-grab active:cursor-grabbing"
+        onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
+        {!currentImage && (
+          <div className="text-gray-500 text-sm">{emptyLabel}</div>
+        )}
+        {currentImage && loading && (
+          <div className="text-gray-400 text-sm animate-pulse">Loading…</div>
+        )}
+        {currentImage && error && (
+          <div className="text-red-400 text-sm">Error: {error}</div>
+        )}
+        {src && (
+          <img
+            src={src}
+            alt={currentImage?.name}
+            draggable={false}
+            className="max-w-none max-h-none pointer-events-none"
+            style={{
+              transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+              transformOrigin: "center center",
+              willChange: "transform",
+              transition: draggingRef.current
+                ? "none"
+                : "transform 50ms ease-out",
+            }}
+          />
+        )}
+      </div>
+
+      {/* Thumbnails strip */}
+      <div className="flex gap-2 overflow-x-auto p-2 bg-gray-50 border-t border-gray-200 min-h-[88px]">
+        {images.length === 0 && (
+          <div className="text-xs text-gray-400 italic px-2 py-4">No images</div>
+        )}
+        {images.map((img, i) => (
+          <Thumbnail
+            key={img.id}
+            image={img}
+            active={i === selectedIndex}
+            onClick={() => onSelect(i)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Thumbnail({
+  image,
+  active,
+  onClick,
+}: {
+  image: QAImage;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const { src, loading } = useBlobUrl(buildFileUrl(image.id, true, 200));
+  return (
+    <button
+      onClick={onClick}
+      title={image.name}
+      className={`relative shrink-0 w-20 h-20 rounded-lg overflow-hidden border-2 transition-all ${
+        active
+          ? "border-blue-500 ring-2 ring-blue-300"
+          : "border-gray-200 hover:border-gray-400"
+      }`}
+    >
+      {loading && (
+        <div className="absolute inset-0 bg-gray-200 animate-pulse" />
+      )}
+      {src && (
+        <img
+          src={src}
+          alt={image.name}
+          className="w-full h-full object-cover"
+          draggable={false}
+        />
+      )}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export default function DriveQA() {
+  const [episodeId, setEpisodeId] = useState<string | null>(null);
+  const [episodeName, setEpisodeName] = useState<string>("");
+  const [scenes, setScenes] = useState<QAScene[]>([]);
+  const [scenesLoading, setScenesLoading] = useState(false);
+  const [scenesError, setScenesError] = useState<string | null>(null);
+
+  const [selectedSceneId, setSelectedSceneId] = useState<string | null>(null);
+  const [sceneDetail, setSceneDetail] = useState<QASceneDetail | null>(null);
+  const [sceneLoading, setSceneLoading] = useState(false);
+
+  const [assetIndex, setAssetIndex] = useState(0);
+  const [resultIndex, setResultIndex] = useState(0);
+
+  const [transform, setTransform] = useState<ViewerTransform>(INITIAL_TRANSFORM);
+  const [syncedZoom, setSyncedZoom] = useState(true);
+  const [assetTransform, setAssetTransform] = useState<ViewerTransform>(INITIAL_TRANSFORM);
+  const [resultTransform, setResultTransform] = useState<ViewerTransform>(INITIAL_TRANSFORM);
+
+  const [reviews, setReviews] = useState<Record<string, QAReview>>({});
+  const [notes, setNotes] = useState("");
+  const [savingReview, setSavingReview] = useState(false);
+
+  // Load episode + scenes + reviews on mount
+  useEffect(() => {
+    setScenesLoading(true);
+    Promise.all([
+      apiGet<{ id: string; name: string }>("/drive-qa/episode"),
+      apiGet<{ success: boolean; scenes: QAScene[]; error?: string }>(
+        "/drive-qa/scenes"
+      ),
+      apiGet<{ success: boolean; reviews: QAReview[]; error?: string }>(
+        "/drive-qa/reviews"
+      ),
+    ])
+      .then(([ep, scenesResp, reviewsResp]) => {
+        setEpisodeId(ep.id);
+        setEpisodeName(ep.name);
+        if (scenesResp.success) {
+          setScenes(scenesResp.scenes);
+          if (scenesResp.scenes.length > 0 && !selectedSceneId) {
+            setSelectedSceneId(scenesResp.scenes[0].id);
+          }
+        } else {
+          setScenesError(scenesResp.error || "Failed to load scenes");
+        }
+        if (reviewsResp.success) {
+          const map: Record<string, QAReview> = {};
+          for (const r of reviewsResp.reviews) map[r.scene_id] = r;
+          setReviews(map);
+        }
+      })
+      .catch((e) => setScenesError(e instanceof Error ? e.message : "Error"))
+      .finally(() => setScenesLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Load scene detail when selection changes
+  useEffect(() => {
+    if (!selectedSceneId) return;
+    setSceneLoading(true);
+    setSceneDetail(null);
+    setAssetIndex(0);
+    setResultIndex(0);
+    setTransform(INITIAL_TRANSFORM);
+    setAssetTransform(INITIAL_TRANSFORM);
+    setResultTransform(INITIAL_TRANSFORM);
+
+    apiGet<{ success: boolean; scene: QASceneDetail | null; error?: string }>(
+      `/drive-qa/scenes/${selectedSceneId}`
+    )
+      .then((resp) => {
+        if (resp.success && resp.scene) {
+          setSceneDetail(resp.scene);
+          setNotes(reviews[selectedSceneId]?.notes ?? "");
+        }
+      })
+      .finally(() => setSceneLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedSceneId]);
+
+  // Reset transforms when changing image within a scene
+  useEffect(() => {
+    setTransform(INITIAL_TRANSFORM);
+    setAssetTransform(INITIAL_TRANSFORM);
+  }, [assetIndex, selectedSceneId]);
+
+  useEffect(() => {
+    setResultTransform(INITIAL_TRANSFORM);
+  }, [resultIndex, selectedSceneId]);
+
+  const currentReview = selectedSceneId ? reviews[selectedSceneId] : undefined;
+  const currentStatus: ReviewStatus = currentReview?.status ?? "pending";
+
+  const statusCounts = useMemo(() => {
+    const counts = { ok: 0, nok: 0, pending: 0 };
+    for (const s of scenes) {
+      const st = reviews[s.id]?.status ?? "pending";
+      counts[st]++;
+    }
+    return counts;
+  }, [scenes, reviews]);
+
+  const handleMarkReview = async (status: ReviewStatus) => {
+    if (!selectedSceneId || !episodeId || !sceneDetail) return;
+    setSavingReview(true);
+    try {
+      const resp = await apiPost<{
+        success: boolean;
+        review: QAReview | null;
+        error?: string;
+      }>("/drive-qa/reviews", {
+        episode_id: episodeId,
+        scene_id: selectedSceneId,
+        scene_name: sceneDetail.name,
+        status,
+        notes: notes || null,
+      });
+      if (resp.success && resp.review) {
+        setReviews((prev) => ({ ...prev, [selectedSceneId]: resp.review! }));
+      }
+    } finally {
+      setSavingReview(false);
+    }
+  };
+
+  return (
+    <div className="h-[calc(100vh-4rem)] flex bg-gray-50">
+      {/* Sidebar with scenes */}
+      <aside className="w-64 shrink-0 border-r border-gray-200 bg-white flex flex-col">
+        <div className="p-4 border-b border-gray-200">
+          <h2 className="font-bold text-gray-900 text-sm">QA Viewer</h2>
+          <p className="text-xs text-gray-500 mt-1">{episodeName}</p>
+          <div className="mt-2 flex gap-2 text-[11px]">
+            <span className="text-green-600">✓ {statusCounts.ok}</span>
+            <span className="text-red-600">✗ {statusCounts.nok}</span>
+            <span className="text-gray-400">· {statusCounts.pending}</span>
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {scenesLoading && (
+            <div className="p-4 text-xs text-gray-500">Loading scenes…</div>
+          )}
+          {scenesError && (
+            <div className="p-4 text-xs text-red-600">{scenesError}</div>
+          )}
+          {scenes.map((s) => {
+            const status = reviews[s.id]?.status ?? "pending";
+            const active = s.id === selectedSceneId;
+            return (
+              <button
+                key={s.id}
+                onClick={() => setSelectedSceneId(s.id)}
+                className={`w-full flex items-center justify-between gap-2 px-4 py-2 text-left text-sm border-l-4 transition-colors ${
+                  active
+                    ? "bg-blue-50 border-blue-500 text-blue-900 font-semibold"
+                    : "border-transparent text-gray-700 hover:bg-gray-50"
+                }`}
+              >
+                <span>{s.name}</span>
+                <StatusBadge status={status} />
+              </button>
+            );
+          })}
+        </div>
+      </aside>
+
+      {/* Main: two viewers side by side */}
+      <div className="flex-1 min-w-0 flex flex-col p-4 gap-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">
+              {sceneDetail?.name ?? "Select a scene"}
+            </h1>
+            {sceneLoading && (
+              <span className="text-xs text-gray-500">Loading…</span>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="flex items-center gap-2 text-xs text-gray-700 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={syncedZoom}
+                onChange={(e) => setSyncedZoom(e.target.checked)}
+              />
+              Synced zoom / pan
+            </label>
+            <button
+              onClick={() => {
+                setTransform(INITIAL_TRANSFORM);
+                setAssetTransform(INITIAL_TRANSFORM);
+                setResultTransform(INITIAL_TRANSFORM);
+              }}
+              className="text-xs px-3 py-1.5 rounded-lg border border-gray-300 hover:bg-gray-100"
+            >
+              Reset view
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 grid grid-cols-2 gap-4">
+          <ViewerPane
+            title="Assets"
+            emptyLabel="No assets in this scene"
+            images={sceneDetail?.assets ?? []}
+            selectedIndex={assetIndex}
+            onSelect={setAssetIndex}
+            transform={syncedZoom ? transform : assetTransform}
+            onTransformChange={syncedZoom ? setTransform : setAssetTransform}
+          />
+          <ViewerPane
+            title="Results"
+            emptyLabel="No result yet for this scene"
+            images={sceneDetail?.results ?? []}
+            selectedIndex={resultIndex}
+            onSelect={setResultIndex}
+            transform={syncedZoom ? transform : resultTransform}
+            onTransformChange={syncedZoom ? setTransform : setResultTransform}
+          />
+        </div>
+
+        {/* QA bar */}
+        {sceneDetail && (
+          <div className="rounded-2xl border border-gray-200 bg-white p-4 flex gap-3 items-center">
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleMarkReview("ok")}
+                disabled={savingReview}
+                className={`px-4 py-2 rounded-lg font-semibold text-sm transition-all ${
+                  currentStatus === "ok"
+                    ? "bg-green-600 text-white shadow"
+                    : "bg-gray-100 text-gray-700 hover:bg-green-100"
+                }`}
+              >
+                ✓ OK
+              </button>
+              <button
+                onClick={() => handleMarkReview("nok")}
+                disabled={savingReview}
+                className={`px-4 py-2 rounded-lg font-semibold text-sm transition-all ${
+                  currentStatus === "nok"
+                    ? "bg-red-600 text-white shadow"
+                    : "bg-gray-100 text-gray-700 hover:bg-red-100"
+                }`}
+              >
+                ✗ NOK
+              </button>
+            </div>
+            <input
+              type="text"
+              placeholder="Notes (optional)"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              onBlur={() => {
+                if (
+                  currentReview &&
+                  (notes || "") !== (currentReview.notes ?? "")
+                ) {
+                  handleMarkReview(currentStatus);
+                }
+              }}
+              className="flex-1 px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:border-blue-500"
+            />
+            {currentReview && (
+              <span className="text-xs text-gray-500">
+                Saved {new Date(currentReview.updated_at).toLocaleString()}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: ReviewStatus }) {
+  if (status === "ok")
+    return (
+      <span className="text-green-600 text-xs font-bold" title="Approved">
+        ✓
+      </span>
+    );
+  if (status === "nok")
+    return (
+      <span className="text-red-600 text-xs font-bold" title="Needs rework">
+        ✗
+      </span>
+    );
+  return <span className="text-gray-300 text-xs">·</span>;
+}

--- a/frontend/src/pages/DriveQA.tsx
+++ b/frontend/src/pages/DriveQA.tsx
@@ -57,8 +57,59 @@ function authHeaders(): HeadersInit {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+// The backend Supabase auth occasionally returns 401 with "Resource temporarily
+// unavailable" when several requests hit in parallel. Retry once after a short
+// delay to ride out the transient error.
+// The backend's Supabase auth check is a sync, blocking call shared by every
+// request. Hitting it from N parallel image loads at once produces EAGAIN
+// 401s. Cap concurrency at 4 in-flight requests at a time.
+const MAX_INFLIGHT = 4;
+let inflight = 0;
+const queue: Array<() => void> = [];
+
+function acquireSlot(): Promise<void> {
+  if (inflight < MAX_INFLIGHT) {
+    inflight++;
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    queue.push(() => {
+      inflight++;
+      resolve();
+    });
+  });
+}
+
+function releaseSlot(): void {
+  inflight--;
+  const next = queue.shift();
+  if (next) next();
+}
+
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  retries = 3,
+): Promise<Response> {
+  await acquireSlot();
+  try {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      const r = await fetch(url, init);
+      if (r.ok) return r;
+      if (attempt === retries) return r;
+      if (r.status !== 401 && r.status < 500) return r;
+      const base = 200 * Math.pow(2, attempt);
+      const jitter = Math.random() * 200;
+      await new Promise((resolve) => setTimeout(resolve, base + jitter));
+    }
+    return fetch(url, init);
+  } finally {
+    releaseSlot();
+  }
+}
+
 async function apiGet<T>(path: string): Promise<T> {
-  const r = await fetch(`${config.apiBaseUrl}${path}`, {
+  const r = await fetchWithRetry(`${config.apiBaseUrl}${path}`, {
     headers: { ...authHeaders() },
   });
   if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
@@ -66,7 +117,7 @@ async function apiGet<T>(path: string): Promise<T> {
 }
 
 async function apiPost<T>(path: string, body: unknown): Promise<T> {
-  const r = await fetch(`${config.apiBaseUrl}${path}`, {
+  const r = await fetchWithRetry(`${config.apiBaseUrl}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify(body),
@@ -99,7 +150,7 @@ function useBlobUrl(url: string | null): { src: string | null; loading: boolean;
     let blobUrl: string | null = null;
     setLoading(true);
     setError(null);
-    fetch(url, { headers: authHeaders() })
+    fetchWithRetry(url, { headers: authHeaders() })
       .then(async (r) => {
         if (!r.ok) throw new Error(`${r.status}`);
         const blob = await r.blob();
@@ -151,27 +202,27 @@ function ViewerPane({
   onTransformChange,
 }: ViewerPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const draggingRef = useRef<{ startX: number; startY: number; tx: number; ty: number } | null>(
-    null
-  );
+  const draggingRef = useRef<{
+    startX: number;
+    startY: number;
+    tx: number;
+    ty: number;
+    moved: boolean;
+  } | null>(null);
 
   const currentImage = images[selectedIndex] ?? null;
   const imageUrl = currentImage ? buildFileUrl(currentImage.id) : null;
   const { src, loading, error } = useBlobUrl(imageUrl);
 
-  // Zoom on wheel — anchor zoom around the cursor position.
-  const handleWheel = useCallback(
-    (e: React.WheelEvent<HTMLDivElement>) => {
-      e.preventDefault();
+  // Cursor-anchored zoom step. `factor > 1` zooms in, `< 1` zooms out.
+  const zoomAroundCursor = useCallback(
+    (clientX: number, clientY: number, factor: number) => {
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
-      const mouseX = e.clientX - rect.left - rect.width / 2;
-      const mouseY = e.clientY - rect.top - rect.height / 2;
-
-      const zoomFactor = Math.exp(-e.deltaY * 0.0015);
-      const newScale = Math.min(8, Math.max(0.2, transform.scale * zoomFactor));
+      const mouseX = clientX - rect.left - rect.width / 2;
+      const mouseY = clientY - rect.top - rect.height / 2;
+      const newScale = Math.min(8, Math.max(0.2, transform.scale * factor));
       const ratio = newScale / transform.scale;
-
       onTransformChange({
         scale: newScale,
         x: mouseX - (mouseX - transform.x) * ratio,
@@ -181,28 +232,37 @@ function ViewerPane({
     [onTransformChange, transform]
   );
 
+  // Mouse down: either trigger a modifier-zoom or start a drag-pan.
   const handleMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
+      // Shift+Click → zoom in towards cursor.
+      // Cmd/Ctrl+Click → zoom out from cursor.
+      if (e.shiftKey || e.metaKey || e.ctrlKey) {
+        e.preventDefault();
+        const factor = e.shiftKey ? 1.5 : 1 / 1.5;
+        zoomAroundCursor(e.clientX, e.clientY, factor);
+        return;
+      }
       e.preventDefault();
       draggingRef.current = {
         startX: e.clientX,
         startY: e.clientY,
         tx: transform.x,
         ty: transform.y,
+        moved: false,
       };
     },
-    [transform]
+    [transform, zoomAroundCursor]
   );
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!draggingRef.current) return;
       const { startX, startY, tx, ty } = draggingRef.current;
-      onTransformChange({
-        ...transform,
-        x: tx + (e.clientX - startX),
-        y: ty + (e.clientY - startY),
-      });
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      if (Math.abs(dx) > 2 || Math.abs(dy) > 2) draggingRef.current.moved = true;
+      onTransformChange({ ...transform, x: tx + dx, y: ty + dy });
     },
     [onTransformChange, transform]
   );
@@ -226,7 +286,6 @@ function ViewerPane({
       <div
         ref={containerRef}
         className="flex-1 relative overflow-hidden bg-[#1a1a1a] flex items-center justify-center select-none cursor-grab active:cursor-grabbing"
-        onWheel={handleWheel}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
@@ -246,7 +305,7 @@ function ViewerPane({
             src={src}
             alt={currentImage?.name}
             draggable={false}
-            className="max-w-none max-h-none pointer-events-none"
+            className="max-w-full max-h-full object-contain pointer-events-none"
             style={{
               transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
               transformOrigin: "center center",
@@ -331,7 +390,7 @@ export default function DriveQA() {
   const [resultIndex, setResultIndex] = useState(0);
 
   const [transform, setTransform] = useState<ViewerTransform>(INITIAL_TRANSFORM);
-  const [syncedZoom, setSyncedZoom] = useState(true);
+  const [syncedZoom, setSyncedZoom] = useState(false);
   const [assetTransform, setAssetTransform] = useState<ViewerTransform>(INITIAL_TRANSFORM);
   const [resultTransform, setResultTransform] = useState<ViewerTransform>(INITIAL_TRANSFORM);
 
@@ -339,38 +398,58 @@ export default function DriveQA() {
   const [notes, setNotes] = useState("");
   const [savingReview, setSavingReview] = useState(false);
 
-  // Load episode + scenes + reviews on mount
+  // Load episode + scenes + reviews on mount. Serialized rather than
+  // Promise.all because parallel auth checks against Supabase occasionally
+  // return EAGAIN 401s from the backend.
   useEffect(() => {
+    let cancelled = false;
     setScenesLoading(true);
-    Promise.all([
-      apiGet<{ id: string; name: string }>("/drive-qa/episode"),
-      apiGet<{ success: boolean; scenes: QAScene[]; error?: string }>(
-        "/drive-qa/scenes"
-      ),
-      apiGet<{ success: boolean; reviews: QAReview[]; error?: string }>(
-        "/drive-qa/reviews"
-      ),
-    ])
-      .then(([ep, scenesResp, reviewsResp]) => {
+
+    (async () => {
+      try {
+        const ep = await apiGet<{ id: string; name: string }>("/drive-qa/episode");
+        if (cancelled) return;
         setEpisodeId(ep.id);
         setEpisodeName(ep.name);
+
+        const scenesResp = await apiGet<{
+          success: boolean;
+          scenes: QAScene[];
+          error?: string;
+        }>("/drive-qa/scenes");
+        if (cancelled) return;
         if (scenesResp.success) {
           setScenes(scenesResp.scenes);
-          if (scenesResp.scenes.length > 0 && !selectedSceneId) {
-            setSelectedSceneId(scenesResp.scenes[0].id);
+          if (scenesResp.scenes.length > 0) {
+            setSelectedSceneId((curr) => curr ?? scenesResp.scenes[0].id);
           }
         } else {
           setScenesError(scenesResp.error || "Failed to load scenes");
         }
+
+        const reviewsResp = await apiGet<{
+          success: boolean;
+          reviews: QAReview[];
+          error?: string;
+        }>("/drive-qa/reviews");
+        if (cancelled) return;
         if (reviewsResp.success) {
           const map: Record<string, QAReview> = {};
           for (const r of reviewsResp.reviews) map[r.scene_id] = r;
           setReviews(map);
         }
-      })
-      .catch((e) => setScenesError(e instanceof Error ? e.message : "Error"))
-      .finally(() => setScenesLoading(false));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+      } catch (e) {
+        if (!cancelled) {
+          setScenesError(e instanceof Error ? e.message : "Error");
+        }
+      } finally {
+        if (!cancelled) setScenesLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Load scene detail when selection changes
@@ -442,12 +521,75 @@ export default function DriveQA() {
     }
   };
 
+  // Keyboard shortcuts:
+  //   A / D       → previous / next asset (left pane)
+  //   ← / →       → previous / next result (right pane)
+  //   ↑ / ↓       → previous / next scene (sidebar)
+  //   R           → reset zoom/pan on both panes
+  // Disabled while typing in the notes field.
+  useEffect(() => {
+    function isTypingTarget(target: EventTarget | null): boolean {
+      if (!(target instanceof HTMLElement)) return false;
+      const tag = target.tagName;
+      return (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        target.isContentEditable
+      );
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (isTypingTarget(e.target)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const assets = sceneDetail?.assets ?? [];
+      const results = sceneDetail?.results ?? [];
+
+      if (e.key === "a" || e.key === "A") {
+        if (assets.length === 0) return;
+        e.preventDefault();
+        setAssetIndex((i) => (i - 1 + assets.length) % assets.length);
+      } else if (e.key === "d" || e.key === "D") {
+        if (assets.length === 0) return;
+        e.preventDefault();
+        setAssetIndex((i) => (i + 1) % assets.length);
+      } else if (e.key === "ArrowLeft") {
+        if (results.length === 0) return;
+        e.preventDefault();
+        setResultIndex((i) => (i - 1 + results.length) % results.length);
+      } else if (e.key === "ArrowRight") {
+        if (results.length === 0) return;
+        e.preventDefault();
+        setResultIndex((i) => (i + 1) % results.length);
+      } else if (e.key === "ArrowUp") {
+        if (scenes.length === 0) return;
+        e.preventDefault();
+        const idx = scenes.findIndex((s) => s.id === selectedSceneId);
+        const next = idx <= 0 ? scenes.length - 1 : idx - 1;
+        setSelectedSceneId(scenes[next].id);
+      } else if (e.key === "ArrowDown") {
+        if (scenes.length === 0) return;
+        e.preventDefault();
+        const idx = scenes.findIndex((s) => s.id === selectedSceneId);
+        const next = idx < 0 || idx === scenes.length - 1 ? 0 : idx + 1;
+        setSelectedSceneId(scenes[next].id);
+      } else if (e.key === "r" || e.key === "R") {
+        e.preventDefault();
+        setTransform(INITIAL_TRANSFORM);
+        setAssetTransform(INITIAL_TRANSFORM);
+        setResultTransform(INITIAL_TRANSFORM);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [sceneDetail, scenes, selectedSceneId]);
+
   return (
     <div className="h-[calc(100vh-4rem)] flex bg-gray-50">
       {/* Sidebar with scenes */}
       <aside className="w-64 shrink-0 border-r border-gray-200 bg-white flex flex-col">
         <div className="p-4 border-b border-gray-200">
-          <h2 className="font-bold text-gray-900 text-sm">QA Viewer</h2>
+          <h2 className="font-bold text-gray-900 text-sm">Max Wild ep 3 QA</h2>
           <p className="text-xs text-gray-500 mt-1">{episodeName}</p>
           <div className="mt-2 flex gap-2 text-[11px]">
             <span className="text-green-600">✓ {statusCounts.ok}</span>
@@ -494,7 +636,15 @@ export default function DriveQA() {
               <span className="text-xs text-gray-500">Loading…</span>
             )}
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-4">
+            <div className="hidden md:flex items-center gap-3 text-[11px] text-gray-500">
+              <span><kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">A</kbd>/<kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">D</kbd> assets</span>
+              <span><kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">←</kbd>/<kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">→</kbd> results</span>
+              <span><kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">↑</kbd>/<kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">↓</kbd> scene</span>
+              <span><kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">⇧</kbd>+click zoom in</span>
+              <span><kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">⌘</kbd>+click zoom out</span>
+              <span><kbd className="font-mono bg-gray-100 border border-gray-300 rounded px-1">R</kbd> reset</span>
+            </div>
             <label className="flex items-center gap-2 text-xs text-gray-700 cursor-pointer">
               <input
                 type="checkbox"


### PR DESCRIPTION
## Summary
- New top-level **Drive QA** page that loads scenes from the Max Wild 1x03 folder in the shared Drive and shows **Assets** (left) vs **Results** (right) side-by-side.
- Reviewers can scrub through thumbnails on each side, zoom/pan with synced or independent controls, and mark each scene **OK / NOK** with notes (persisted in Supabase).
- Backend reuses the existing Google Drive service account; frontend proxies image bytes through the API so auth stays server-side.

## Changes
- **Backend**
  - `api/drive_qa.py` — endpoints: list scenes, scene detail, file/thumbnail proxy, list/upsert reviews. All auth-gated via `get_current_user`.
  - `services/drive_qa_service.py` — Drive accessor (lists scenes under `3. Master Shot - Layout`, splits each scene into the `Assets/` subfolder + result images sitting at the scene root). Also wraps the new `drive_qa_reviews` table.
  - `models/drive_qa.py` — Pydantic models.
  - `migrations/009_add_drive_qa_reviews.sql` — table with RLS (team-wide read, owner-only write). **Already applied to the VAPAI app project (`rwbhfxltyxaegtalgxdx`)** via the Supabase MCP.
- **Frontend**
  - `pages/DriveQA.tsx` — sidebar scene list with status badges, dual viewer panes (custom wheel-zoom + drag-pan + optional sync), thumbnail strips, OK/NOK + notes bar.
  - `lib/studioConfig.ts` — `drive-qa` added to `StudioPageType` and `standaloneApps` (tile appears on homepage).
  - `App.tsx` — sidebar button under **Tools**, route in `validPages`, conditional render.

## Hardcoded for now
- Episode folder ID `1_yPGxVUQ5C55jfvmbN93WH6uLfiKivUq` (Max Wild 1x03) and the `3. Master Shot - Layout` folder ID. When we need more episodes we'll lift these into a registry/table.

## Out of scope / heads-up
- Supabase advisory flags 8 **preexisting** tables with RLS disabled (`video_jobs`, `image_jobs`, `batch_jobs`, `batch_job_items`, `project_folders`, `upscale_batches`, `upscale_videos`, `world_jobs`). Not introduced here — flagged separately for a future PR.

## Test plan
- [ ] Backend boots without import errors (`uvicorn main:app --reload`)
- [ ] `GET /api/drive-qa/scenes` returns 83 `Scene NN` entries when authenticated
- [ ] `GET /api/drive-qa/scenes/{scene_id}` for Scene 07 returns ≥1 result image and ≥1 asset image
- [ ] Image proxy `GET /api/drive-qa/file/{file_id}` returns image bytes (with auth header)
- [ ] Thumbnail proxy returns a smaller payload than the full image
- [ ] Page loads from sidebar; selecting a scene swaps both panes
- [ ] Scroll-wheel zooms around the cursor; click-drag pans
- [ ] "Synced zoom / pan" toggle decouples the two panes
- [ ] OK/NOK button persists across reload; sidebar badge updates
- [ ] Notes save on blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)