### PR TITLE
dev → main: drive-qa perf improvements

### DIFF
--- a/backend/api/drive_qa.py
+++ b/backend/api/drive_qa.py
@@ -12,8 +12,10 @@ Exposes:
 
 from __future__ import annotations
 
-import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+import hashlib
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import Response
 
 from core.auth import get_current_user
@@ -81,7 +83,12 @@ async def get_file_bytes(
     file_id: str,
     _: dict = Depends(get_current_user),
 ) -> Response:
-    """Stream the full image bytes for a Drive file."""
+    """Stream the full (original) image bytes for a Drive file.
+
+    Cached server-side; large files (multi-MB) so still slower than `preview`.
+    Use this only when the viewer needs the source quality (e.g. "Original"
+    button).
+    """
     service = DriveQAService()
     success, content, mime_type, error = await service.download_file(file_id)
     if not success or content is None:
@@ -93,41 +100,70 @@ async def get_file_bytes(
     )
 
 
+def _image_response(
+    content: bytes,
+    mime: Optional[str],
+    file_id: str,
+    variant: str,
+    size: int,
+    if_none_match: Optional[str],
+) -> Response:
+    """Return image bytes with ETag + Cache-Control headers, or 304 if the
+    client already has the same version."""
+    # ETag built from path + size + a hash of the bytes so it changes when
+    # the underlying file does.
+    digest = hashlib.sha1(content).hexdigest()[:16]
+    etag = f'W/"{file_id}-{variant}-{size}-{digest}"'
+    if if_none_match and if_none_match.strip() == etag:
+        return Response(status_code=304)
+    return Response(
+        content=content,
+        media_type=mime or "image/jpeg",
+        headers={
+            "Cache-Control": "private, max-age=86400",
+            "ETag": etag,
+        },
+    )
+
+
+@router.get("/file/{file_id}/preview")
+async def get_file_preview(
+    file_id: str,
+    size: int = Query(2000, ge=200, le=4000),
+    if_none_match: Optional[str] = Header(None, alias="If-None-Match"),
+    _: dict = Depends(get_current_user),
+) -> Response:
+    """Medium-resolution JPEG preview (default for the main viewer pane).
+
+    Served from the backend's in-memory TTLCache after the first hit. Returns
+    304 Not Modified when the browser already has the same ETag.
+    """
+    service = DriveQAService()
+    success, content, mime, error = await service.get_preview_bytes(
+        file_id, size_px=size
+    )
+    if not success or content is None:
+        raise HTTPException(status_code=502, detail=error or "Drive preview unavailable")
+    return _image_response(content, mime, file_id, "preview", size, if_none_match)
+
+
 @router.get("/file/{file_id}/thumbnail")
 async def get_file_thumbnail(
     file_id: str,
-    size: int = Query(400, ge=64, le=2000),
+    size: int = Query(400, ge=64, le=600),
+    if_none_match: Optional[str] = Header(None, alias="If-None-Match"),
     _: dict = Depends(get_current_user),
 ) -> Response:
-    """Proxy a Drive-generated thumbnail (smaller than the full image)."""
+    """Small thumbnail (≤600px) for the thumbnails strip."""
     service = DriveQAService()
-    success, url, error = await service.get_thumbnail_url(file_id, size_px=size)
-    if not success or not url:
-        # Fall back to the full image if the thumbnail is unavailable.
-        full_success, content, mime, full_error = await service.download_file(file_id)
-        if not full_success or content is None:
-            raise HTTPException(
-                status_code=502,
-                detail=error or full_error or "Drive thumbnail unavailable",
-            )
-        return Response(
-            content=content,
-            media_type=mime or "image/jpeg",
-            headers={"Cache-Control": "private, max-age=3600"},
-        )
-
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            r = await client.get(url)
-            r.raise_for_status()
-    except httpx.HTTPError as e:
-        raise HTTPException(status_code=502, detail=f"Thumbnail fetch failed: {e}")
-
-    return Response(
-        content=r.content,
-        media_type=r.headers.get("content-type", "image/jpeg"),
-        headers={"Cache-Control": "private, max-age=3600"},
+    success, content, mime, error = await service.get_preview_bytes(
+        file_id, size_px=size
     )
+    if not success or content is None:
+        raise HTTPException(
+            status_code=502, detail=error or "Drive thumbnail unavailable"
+        )
+    return _image_response(content, mime, file_id, "thumb", size, if_none_match)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/drive_qa_service.py
+++ b/backend/services/drive_qa_service.py
@@ -16,11 +16,35 @@ import io
 import re
 from typing import List, Optional, Tuple
 
+import httpx
+from cachetools import TTLCache
 from googleapiclient.http import MediaIoBaseDownload
 
 from core.google_drive import get_drive_client, is_drive_configured
 from core.supabase import get_supabase
 from models.drive_qa import QAImage, QAReview, QAScene, QASceneDetail, ReviewStatus
+
+
+# ---------------------------------------------------------------------------
+# Caches (process-local, in-memory)
+# ---------------------------------------------------------------------------
+#
+# Drive QA traffic is read-heavy (the same images get pulled many times as
+# reviewers navigate scenes). Caching avoids both the per-request 401 storms
+# from the backend's Supabase auth pool and the Drive bandwidth cost.
+#
+# Three caches, sized so the total stays ~500 MB worst case:
+#   - thumbnail cache (small JPEGs): keys "id:size" → bytes + mime
+#   - preview cache (medium JPEGs): same key shape
+#   - full cache (original bytes): keyed by file_id; smaller maxsize because
+#     entries can be 20+ MB each.
+#
+# `cachetools.TTLCache` evicts both on size and on TTL so memory can't grow
+# without bound.
+
+_THUMB_CACHE: TTLCache[str, Tuple[bytes, str]] = TTLCache(maxsize=512, ttl=60 * 30)
+_PREVIEW_CACHE: TTLCache[str, Tuple[bytes, str]] = TTLCache(maxsize=128, ttl=60 * 30)
+_FULL_CACHE: TTLCache[str, Tuple[bytes, str]] = TTLCache(maxsize=24, ttl=60 * 30)
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +159,12 @@ class DriveQAService:
                 for c in children
                 if c["mimeType"].startswith(IMAGE_MIME_PREFIX)
             ]
-            results.sort(key=lambda i: i.name.lower())
+            # Newest first: the reviewer almost always wants to see the most
+            # recent render. Fall back to name when modifiedTime is missing.
+            results.sort(
+                key=lambda i: (i.modified_time or "", i.name.lower()),
+                reverse=True,
+            )
 
             # Assets = images inside the scene's `Assets/` subfolder (if any).
             assets_folder = next(
@@ -179,12 +208,17 @@ class DriveQAService:
     async def download_file(
         self, file_id: str
     ) -> Tuple[bool, Optional[bytes], Optional[str], Optional[str]]:
-        """Download the full bytes of a Drive file.
+        """Download the full bytes of a Drive file (cached).
 
         Returns (success, content, mime_type, error).
         """
         if not self.drive:
             return False, None, None, "Google Drive not configured"
+
+        cached = _FULL_CACHE.get(file_id)
+        if cached is not None:
+            content, mime_type = cached
+            return True, content, mime_type, None
 
         try:
             meta = self.drive.files().get(
@@ -204,21 +238,41 @@ class DriveQAService:
             while not done:
                 _status, done = downloader.next_chunk()
 
-            return True, buf.getvalue(), mime_type, None
+            content = buf.getvalue()
+            _FULL_CACHE[file_id] = (content, mime_type)
+            return True, content, mime_type, None
 
         except Exception as e:
             return False, None, None, str(e)
 
-    async def get_thumbnail_url(
-        self, file_id: str, size_px: int = 800
-    ) -> Tuple[bool, Optional[str], Optional[str]]:
-        """Get a Drive-generated thumbnail link, resized to `size_px` on the long side.
+    async def get_preview_bytes(
+        self,
+        file_id: str,
+        size_px: int = 2000,
+    ) -> Tuple[bool, Optional[bytes], Optional[str], Optional[str]]:
+        """Fetch a resized JPEG preview of the file, served through Drive's
+        thumbnail endpoint.
 
-        Drive's thumbnailLink looks like `...=s220`; we swap the size param.
-        Returns (success, url, error).
+        This is much faster than `download_file` for two reasons:
+          1. Drive returns an already-compressed JPEG (not the source PNG).
+          2. The smaller payload (typically 200KB–2MB instead of 5–20MB)
+             traverses our backend → browser pipe much faster.
+
+        Falls back to a 1600px size if Drive caps the request. If even that
+        fails (some file types have no thumbnail), the caller can fall back
+        to `download_file`.
+
+        Cached by (file_id, size).
         """
         if not self.drive:
-            return False, None, "Google Drive not configured"
+            return False, None, None, "Google Drive not configured"
+
+        cache_key = f"{file_id}:{size_px}"
+        target_cache = _THUMB_CACHE if size_px <= 600 else _PREVIEW_CACHE
+        cached = target_cache.get(cache_key)
+        if cached is not None:
+            content, mime_type = cached
+            return True, content, mime_type, None
 
         try:
             meta = self.drive.files().get(
@@ -228,14 +282,27 @@ class DriveQAService:
             ).execute()
             link = meta.get("thumbnailLink")
             if not link:
-                return False, None, "No thumbnail available"
+                return False, None, None, "No thumbnail available"
 
-            # Drive returns links ending in `=sNNN`; resize by replacing it.
+            # Drive thumbnailLinks end in `=sNNN` (sometimes with `-c` crop suffix).
+            # Replace with the size we want.
             resized = re.sub(r"=s\d+(-c)?$", f"=s{size_px}", link)
-            return True, resized, None
+
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                r = await client.get(resized)
+                if r.status_code != 200 and size_px > 1600:
+                    # Drive sometimes caps at 1600 — retry once.
+                    resized = re.sub(r"=s\d+(-c)?$", "=s1600", link)
+                    r = await client.get(resized)
+                r.raise_for_status()
+
+            content = r.content
+            mime_type = r.headers.get("content-type", "image/jpeg")
+            target_cache[cache_key] = (content, mime_type)
+            return True, content, mime_type, None
 
         except Exception as e:
-            return False, None, str(e)
+            return False, None, None, str(e)
 
     # ------------------------------------------------------------------
     # Internal

--- a/frontend/src/pages/DriveQA.tsx
+++ b/frontend/src/pages/DriveQA.tsx
@@ -127,9 +127,24 @@ async function apiPost<T>(path: string, body: unknown): Promise<T> {
 }
 
 // Build a URL the <img> can hit — needs auth, so we use blob URLs via fetch.
-function buildFileUrl(fileId: string, thumbnail = false, size = 1200): string {
-  const suffix = thumbnail ? `/thumbnail?size=${size}` : "";
-  return `${config.apiBaseUrl}/drive-qa/file/${fileId}${suffix}`;
+//
+// Three modes:
+//   - "thumb"   → small JPEG for the thumbnails strip (<=600px).
+//   - "preview" → medium JPEG for the main viewer pane (default).
+//   - "full"    → original bytes, only when the user asks for source quality.
+type ImageVariant = "thumb" | "preview" | "full";
+
+function buildFileUrl(
+  fileId: string,
+  variant: ImageVariant = "preview",
+  size?: number,
+): string {
+  const base = `${config.apiBaseUrl}/drive-qa/file/${fileId}`;
+  if (variant === "full") return base;
+  if (variant === "thumb") {
+    return `${base}/thumbnail?size=${size ?? 400}`;
+  }
+  return `${base}/preview?size=${size ?? 2000}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -211,8 +226,16 @@ function ViewerPane({
   } | null>(null);
 
   const currentImage = images[selectedIndex] ?? null;
-  const imageUrl = currentImage ? buildFileUrl(currentImage.id) : null;
-  const { src, loading, error } = useBlobUrl(imageUrl);
+  // Progressive load: show the small thumbnail (which is usually already
+  // cached by the strip) as a placeholder while the medium preview arrives.
+  const thumbUrl = currentImage ? buildFileUrl(currentImage.id, "thumb", 400) : null;
+  const previewUrl = currentImage ? buildFileUrl(currentImage.id, "preview") : null;
+  const thumb = useBlobUrl(thumbUrl);
+  const preview = useBlobUrl(previewUrl);
+  const src = preview.src ?? thumb.src;
+  const loading = !preview.src && !thumb.src && (preview.loading || thumb.loading);
+  const error = preview.error && !thumb.src ? preview.error : null;
+  const showingHighRes = preview.src !== null;
 
   // Cursor-anchored zoom step. `factor > 1` zooms in, `< 1` zooms out.
   const zoomAroundCursor = useCallback(
@@ -310,11 +333,17 @@ function ViewerPane({
               transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
               transformOrigin: "center center",
               willChange: "transform",
+              filter: showingHighRes ? undefined : "blur(2px)",
               transition: draggingRef.current
                 ? "none"
-                : "transform 50ms ease-out",
+                : "transform 50ms ease-out, filter 200ms ease-out",
             }}
           />
+        )}
+        {currentImage && !showingHighRes && thumb.src && preview.loading && (
+          <div className="absolute top-2 right-2 text-[10px] text-white/70 bg-black/40 px-2 py-1 rounded animate-pulse">
+            Loading high-res…
+          </div>
         )}
       </div>
 
@@ -345,7 +374,7 @@ function Thumbnail({
   active: boolean;
   onClick: () => void;
 }) {
-  const { src, loading } = useBlobUrl(buildFileUrl(image.id, true, 200));
+  const { src, loading } = useBlobUrl(buildFileUrl(image.id, "thumb", 200));
   return (
     <button
       onClick={onClick}
@@ -485,6 +514,50 @@ export default function DriveQA() {
   useEffect(() => {
     setResultTransform(INITIAL_TRANSFORM);
   }, [resultIndex, selectedSceneId]);
+
+  // Prefetch neighbours so D / → feel instant: when the user lands on an
+  // image, fire-and-forget requests for ±1 in the same list. The backend
+  // caches the response so the actual navigation just reads from cache.
+  useEffect(() => {
+    const assets = sceneDetail?.assets ?? [];
+    const results = sceneDetail?.results ?? [];
+
+    function prefetch(url: string | null) {
+      if (!url) return;
+      fetch(url, { headers: authHeaders() }).catch(() => {});
+    }
+
+    function neighbour(list: QAImage[], i: number, delta: number) {
+      if (list.length < 2) return null;
+      const idx = (i + delta + list.length) % list.length;
+      return list[idx]?.id ?? null;
+    }
+
+    const nextAsset = neighbour(assets, assetIndex, 1);
+    const prevAsset = neighbour(assets, assetIndex, -1);
+    const nextResult = neighbour(results, resultIndex, 1);
+    const prevResult = neighbour(results, resultIndex, -1);
+
+    if (nextAsset) prefetch(buildFileUrl(nextAsset, "preview"));
+    if (prevAsset) prefetch(buildFileUrl(prevAsset, "preview"));
+    if (nextResult) prefetch(buildFileUrl(nextResult, "preview"));
+    if (prevResult) prefetch(buildFileUrl(prevResult, "preview"));
+  }, [sceneDetail, assetIndex, resultIndex]);
+
+  // Prefetch the next scene's first image too, so ↓ feels snappy.
+  useEffect(() => {
+    if (!selectedSceneId || scenes.length < 2) return;
+    const idx = scenes.findIndex((s) => s.id === selectedSceneId);
+    if (idx < 0) return;
+    const nextScene = scenes[(idx + 1) % scenes.length];
+    if (!nextScene) return;
+    // The scene detail isn't cached client-side yet, so we just warm the
+    // backend's per-scene response. The image proxy cache takes over once
+    // the user actually visits the scene.
+    fetch(`${config.apiBaseUrl}/drive-qa/scenes/${nextScene.id}`, {
+      headers: authHeaders(),
+    }).catch(() => {});
+  }, [selectedSceneId, scenes]);
 
   const currentReview = selectedSceneId ? reviews[selectedSceneId] : undefined;
   const currentStatus: ReviewStatus = currentReview?.status ?? "pending";


### PR DESCRIPTION
Promotes #140 to production.

- Faster image loading (medium preview + in-memory cache + browser cache via Cache-Control/ETag)
- Results in a scene sorted newest-first
- Progressive load (thumb → preview with blur)
- Prefetch of ±1 neighbours

🤖 Generated with [Claude Code](https://claude.com/claude-code)